### PR TITLE
feat: ability to provide custom interfaces&codec register in Provide

### DIFF
--- a/runtime/module.go
+++ b/runtime/module.go
@@ -81,7 +81,11 @@ func init() {
 	)
 }
 
-func ProvideApp(interfaceRegistry codectypes.InterfaceRegistry) (
+func ProvideApp(
+	interfaceRegistry codectypes.InterfaceRegistry,
+	customRegisterInterfaces CustomRegisterInterfaces,
+	customRegisterLegacyAminoCodec CustomRegisterLegacyAminoCodec,
+) (
 	codec.Codec,
 	*codec.LegacyAmino,
 	*AppBuilder,
@@ -104,8 +108,16 @@ func ProvideApp(interfaceRegistry codectypes.InterfaceRegistry) (
 
 	amino := codec.NewLegacyAmino()
 
-	std.RegisterInterfaces(interfaceRegistry)
-	std.RegisterLegacyAminoCodec(amino)
+	if customRegisterInterfaces != nil {
+		customRegisterInterfaces(interfaceRegistry)
+	} else {
+		std.RegisterInterfaces(interfaceRegistry)
+	}
+	if customRegisterLegacyAminoCodec != nil {
+		customRegisterLegacyAminoCodec(amino)
+	} else {
+		std.RegisterLegacyAminoCodec(amino)
+	}
 
 	cdc := codec.NewProtoCodec(interfaceRegistry)
 	msgServiceRouter := baseapp.NewMsgServiceRouter()

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -4,6 +4,7 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -39,3 +40,7 @@ type AppI interface {
 	// Helper for the simulation framework.
 	SimulationManager() *module.SimulationManager
 }
+
+type CustomRegisterInterfaces func(codectypes.InterfaceRegistry)
+
+type CustomRegisterLegacyAminoCodec func(*codec.LegacyAmino)


### PR DESCRIPTION
Add `CustomRegisterInterfaces` and `CustomRegisterLegacyAminoCodec` to allow register evmos codec and interfaces from depinject.Config.

Example of using: https://github.com/warden-protocol/wardenprotocol/blob/main/warden/app/app.go#L213